### PR TITLE
Moved events out of JurorStore

### DIFF
--- a/SmartContract/src/JurorStore.sol
+++ b/SmartContract/src/JurorStore.sol
@@ -26,12 +26,14 @@ contract JurorStore{
         jurors.push(address(0));
     }
 
-    function addJuror(address j) public onlyOwner(){
+    function addJuror(address j) public onlyOwner() returns(uint256){
+        require(jurorIndex[j] == 0, "You are already a juror");
+
         uint256 index = jurors.length;
         jurors.push(j);
         numJurors++;
         jurorIndex[j] = index;
-        emit AddJuror(j, index);
+        return index;
     }
 
     function removeJuror(address j) public onlyOwner(){
@@ -50,8 +52,6 @@ contract JurorStore{
         jurors.pop();
         numJurors--;
         jurorIndex[j] = 0;
-
-        emit RemoveJuror(j);
     }
 
     // Cleared after every execution of assignJury
@@ -110,8 +110,5 @@ contract JurorStore{
 
         return result;
     }
-
-    event AddJuror(address juror, uint256 index);
-    event RemoveJuror(address juror);
 
 }

--- a/SmartContract/src/Verifier.sol
+++ b/SmartContract/src/Verifier.sol
@@ -240,12 +240,14 @@ contract Verifier{
         unisonToken.transferFrom(j, address(this), stakingAmount);
 
         jurorStore.addJuror(j);
+        emit AddJuror(j);
     }
 
     // remove yourself from available jurors list
     function removeJuror() public{
         jurorStore.removeJuror(msg.sender);
         unisonToken.transfer(msg.sender, stakingAmount);
+        emit RemoveJuror(msg.sender);
     }
 
     function _jurorIndex(uint agreeID) internal view returns(int){
@@ -355,5 +357,8 @@ contract Verifier{
     event CloseAgreement(uint agreeID);
 
     event JuryAssigned(uint agreeID, address[] jury);
+
+    event AddJuror(address juror);
+    event RemoveJuror(address juror);
 
 }

--- a/SmartContract/test/JurorStore.test.js
+++ b/SmartContract/test/JurorStore.test.js
@@ -29,9 +29,6 @@ contract('JurorStore', (accounts) =>{
             catch(e){}
 
             assert(passedRequire == true, "Could not add juror");
-            truffleAssert.eventEmitted(result, "AddJuror", (ev)=>{
-                return ev.juror == accounts[1]
-            });
         })
 
         it("Can't add a juror as non-owner", async() =>{
@@ -47,8 +44,9 @@ contract('JurorStore', (accounts) =>{
 
 
         it("AssignJury assigns a jury", async() =>{
-            for(var i=1; i<10; i++){
-                await jurorStore.addJuror(accounts[1], {from: accounts[0]});
+            // accounts[1] already added as a juror in a previous test
+            for(var i=2; i<10; i++){
+                await jurorStore.addJuror(accounts[i], {from: accounts[0]});
 
             }
   


### PR DESCRIPTION
Helps other systems to read events properly, since JurorStore's address is hard to publicly find